### PR TITLE
Feat/hackathon banner

### DIFF
--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -3,7 +3,7 @@ layout: skeleton
 ---
 <style>
     .bg-hero {
-        background: url('{{site.baseurl}}/images/hero-banner.png') no-repeat top center;
+        background: url('{{site.baseurl}}/images/Hack2021Banner-FINAL.png') no-repeat top center;
         -webkit-background-size: cover;
         background-size: cover;
     }

--- a/misc/custom.scss
+++ b/misc/custom.scss
@@ -441,10 +441,10 @@ $widescreen: 1152px + (4 * $gap) !default;
   }
 }
 
-.bp-hero-body {
-  background-color: #000000;
-  opacity: 0.75;
-}
+// .bp-hero-body {
+//   background-color: #000000;
+//   opacity: 0.75;
+// }
 
 a.navbar-item {
   width: 180px;


### PR DESCRIPTION
This PR temporarily sets the hero banner on the front page of OGP site to the hackathon banner, and disables the black overlay until the other banner is restored.