### PR TITLE
fix(media): fixed newsroom not showing articles

### DIFF
--- a/Media/articles/_posts/2021-06-27-post-li-hongyi-how-to-build-good-software.md
+++ b/Media/articles/_posts/2021-06-27-post-li-hongyi-how-to-build-good-software.md
@@ -1,6 +1,0 @@
----
-title: "Li Hongyi: How to Build Good Software"
-date: 2021-06-27
-permalink: /Media/articles/permalink
-layout: post
----

--- a/Media/articles/index.html
+++ b/Media/articles/index.html
@@ -1,4 +1,0 @@
----
-layout: resources-alt
-title: Articles
----

--- a/Media/articles/media.md
+++ b/Media/articles/media.md
@@ -1,0 +1,5 @@
+---
+title: Media
+permalink: /media/
+---
+{% include media.html careers=site.data.media %}

--- a/_newsroom/collection.yml
+++ b/_newsroom/collection.yml
@@ -1,5 +1,0 @@
-collections:
-  newsroom:
-    output: true
-    order:
-      - media.md

--- a/_newsroom/media.md
+++ b/_newsroom/media.md
@@ -1,7 +1,0 @@
----
-title: Media
-permalink: /media/
----
-
-
-{% include media.html careers=site.data.media %}


### PR DESCRIPTION
## Problem 
the current ogp [website](https://www.open.gov.sg/media/) has an empty `media` tab. it only displays 2 headers with no content.
 
However, a [previous version](https://web.archive.org/web/20220616082350/https://www.open.gov.sg/media) of the exact same tab shows content being displayed. 

## Solution 
This was caused by a confusion caused by resource room. As the ogp `_config.yml` has a resource room set to `Media`, the url `open.gov.sg/media` instead displays the resource room. this was solved by shifting the content rooted at `_newsroom/` to be under `Media/articles`