### PR TITLE
fix: restore function colors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,13 @@ colors:
       color: "#00838f"
     - title: media-color-five
       color: "#00838f"
+  function-colors:
+    corporate: "#1361F0"
+    design: "#2D978C"
+    eng: "#E74F4F"
+    ops: "#5D6785"
+    pm: "#C4992A"
+    transformation: "#272D41"
 google_analytics: UA-189280200-1
 staging: https://ogp-staging.netlify.app
 prod: https://isomer-opengovsg-prod.netlify.app


### PR DESCRIPTION
## context
Staff pages are broken because the the function colors have been (accidentally?) deleted in [this PR](https://github.com/isomerpages/ogp/pull/170/files#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883)

![image](https://github.com/isomerpages/ogp/assets/935223/ddfe4303-e478-4fee-8d17-3320f2ee9468)

![image](https://github.com/isomerpages/ogp/assets/935223/6c466529-2b46-4245-b87a-d057e1b3e9e2)

## approach
Restore definitions of function colors
