### PR TITLE
fix: restore government masthead + fix landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,5 +53,5 @@ exclude:
 include:
   - _redirects
 shareicon: /images/isomer-logo.svg
-is_government: false
+is_government: true
 google_analytics_ga4: G-PECHXJ1ZZC

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -18,11 +18,15 @@ layout: skeleton
     
     .hero-text-container {
         /* Banner is 450px, padding-top/bottom is 3rem each */
-        top: 175px; 
+        top: 260px;
         transform: translateY(-50%);
     }
 
     @media screen and (max-width: 658px) {
+      .hero-text-container {
+        top: 175px;
+      }
+
       div #big-text {
         font-size: 28.03px;
         padding-left: 0.5em;

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -15,16 +15,10 @@ layout: skeleton
         -webkit-background-size: cover;
         background-size: cover;
     }
-    
-    .hero-text-container {
-        /* Banner is 450px, padding-top/bottom is 3rem each */
-        top: 260px;
-        transform: translateY(-50%);
-    }
 
     @media screen and (max-width: 658px) {
       .hero-text-container {
-        top: 175px;
+        top: 175px; /* this is bad, we should have a flex vertical center align instead */
       }
 
       div #big-text {

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -60,34 +60,30 @@ layout: skeleton
         line-height: calc(5px + 3.5vw);
         color: rgb(39, 110, 241);
     }
-    
+
     .no-tall-banner {
         height: auto !important;
         min-height: auto !important;
     }
-    
+
     .scrolling-words-box ul {
         padding: 0;
         animation: scrollUp 5s infinite;
     }
 
     @keyframes scrollUp {
-        10%, 20% {
-            transform: translateY(-16.666%);
+        12.5%, 25% {
+            transform: translateY(-20%);
         }
-        30%, 40% {
-            transform: translateY(-33.333%);
+        37.5%, 50% {
+            transform: translateY(-40%);
         }
-        50%, 60% {
-            transform: translateY(-49.999%);
+        62.5%, 75% {
+            transform: translateY(-60%);
         }
-        70%, 80% {
-            transform: translateY(-66.665%);
+        87.5%, 100% {
+            transform: translateY(-80%);
         }
-        90%, 100% {
-            transform: translateY(-83.331%);
-        }
-
     }
 
 </style>

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -68,7 +68,7 @@ layout: skeleton
 
     .scrolling-words-box ul {
         padding: 0;
-        animation: scrollUp 5s infinite;
+        animation: scrollUp 4s infinite;
     }
 
     @keyframes scrollUp {

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -87,9 +87,9 @@ layout: skeleton
         90%, 100% {
             transform: translateY(-83.331%);
         }
-        
+
     }
-    
+
 </style>
 
 <section class="bp-hero bg-hero">
@@ -108,6 +108,7 @@ layout: skeleton
                             <li>fight scams</li>
                             <li>automate work</li>
                             <li>hack</li>
+                            <li>build tech</li>
                         </ul>
                     </div>
                   <br>

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -25,6 +25,7 @@ layout: skeleton
     @media screen and (max-width: 658px) {
       div #big-text {
         font-size: 28.03px;
+        padding-left: 0.5em;
       }
     
       span .scrolling-words-box {

--- a/_layouts/opengovsg-landing-page.html
+++ b/_layouts/opengovsg-landing-page.html
@@ -105,11 +105,9 @@ layout: skeleton
                     <div class="scrolling-words-box">
                         <ul>
                             <li>build tech</li>
-                             <li>fight scams</li>
-                          <li> automate work</li>
-                            <li> reimagine government</li>
-                                <li>hack</li>
-                             <li> build tech</li>
+                            <li>fight scams</li>
+                            <li>automate work</li>
+                            <li>hack</li>
                         </ul>
                     </div>
                   <br>


### PR DESCRIPTION
## Context

1. Masthead was accidentally (?) removed with this commit:
https://github.com/isomerpages/ogp/commit/e0350df984ef32d4e6664e9a236acd7005e745b9

2. Layout for landing page big cycling text was broken in size and and vertical position, both in desktop and mobile view

## Approach

* This PR restores `is_government:true` to the OGP site
* Quick layout fixes. Would need a bigger/better refactor of the css at some point.


