### PR TITLE
Adding about pages for Mike and Pras

### DIFF
--- a/_about-us/collection.yml
+++ b/_about-us/collection.yml
@@ -28,7 +28,9 @@ collections:
       - design/jingyi.md
       - design/khaleedah.md
       - design/natalie.md
+      - design/mike.md
       - design/pearly.md
+      - design/pras.md
       - design/qimmy.md
       - design/rachel.md
       - design/sarahsalim.md

--- a/_about-us/design/mike.md
+++ b/_about-us/design/mike.md
@@ -1,0 +1,19 @@
+---
+title: Mike Chen
+permalink: /people/mike
+description: Mike Chen - Product Design Manager
+third_nav_title: Product Design
+staffId: mike
+name: Mike Chen
+joinDate: August 21, 2023
+functionId: design
+jobTitle: Product Design Manager
+curProducts: []
+pastProducts: []
+accomplishments:
+  - Onboarding into OGP and building relationships with the Product Design Team
+quote: []
+linkedinId: "slidbook"
+---
+
+{% include staff.html staff=page color=site.colors.function-colors.design %}

--- a/_about-us/design/pras.md
+++ b/_about-us/design/pras.md
@@ -1,0 +1,18 @@
+---
+title: Prasanth Kumaar
+permalink: /people/pras
+description: Prasanth Kumaar - Product Designer
+third_nav_title: Product Design
+staffId: pras
+name: Prasanth Kumaar
+joinDate: September 6, 2023
+functionId: design
+jobTitle: Product Designer
+curProducts: Postman
+pastProducts: []
+accomplishments:[]
+quote: []
+linkedinId: "prasanthkk"
+---
+
+{% include staff.html staff=page color=site.colors.function-colors.design %}


### PR DESCRIPTION
Added pages for Mike and Pras within the Design section of the About Us page. They're still missing some details but have the baseline requirements for a profile page.