### PR TITLE
feat: assign formsg to 2 categories

### DIFF
--- a/_data/products.yml
+++ b/_data/products.yml
@@ -48,7 +48,9 @@
   title: FormSG
   alias:
     - FormSG
-  category: productivity
+  category:
+    - productivity
+    - payments
   image: https://file.go.gov.sg/formsg-logo-2.png
   sum: Build government forms in minutes
   link: https://products.open.gov.sg/formsg

--- a/_includes/ogp-products.html
+++ b/_includes/ogp-products.html
@@ -74,17 +74,17 @@
     }
 </style>
 
-{%- assign products = include.products | where: "category", "productivity" -%}
+{%- assign products = include.products | where_exp: "product", "product.category contains 'productivity'" -%}
 {% include products_section.html products=products sectionTitle="Productivity Tools for Public Officers" %}
 
-{%- assign products = include.products | where: "category", "gov-digital-infrastructure" -%}
+{%- assign products = include.products | where_exp: "product", "product.category contains 'gov-digital-infrastructure'" -%}
 {% include products_section.html products=products sectionTitle="Government Digital Infrastructure" %}
 
-{%- assign products = include.products | where: "category", "anti-scam" -%}
+{%- assign products = include.products | where_exp: "product", "product.category contains 'anti-scam'" -%}
 {% include products_section.html products=products sectionTitle="Anti-Scam" %}
 
-{%- assign products = include.products | where: "category", "payments" -%}
+{%- assign products = include.products | where_exp: "product", "product.category contains 'payments'" -%}
 {% include products_section.html products=products sectionTitle="Payments" %}
 
-{%- assign products = include.products | where: "category", "healthcare" -%}
+{%- assign products = include.products | where_exp: "product", "product.category contains 'healthcare'" -%}
 {% include products_section.html products=products sectionTitle="Healthcare" %}


### PR DESCRIPTION
## Context

Since FormSG has payment capabilities, @amitogp has requested to have the product in 2 categories, with Approval from @cakesoccer


## Approach

Allow `product.category` to be a list rather than a single value with exact match.


verified working on local copy
